### PR TITLE
Fix Message Verification (updates #5)

### DIFF
--- a/message/encode.go
+++ b/message/encode.go
@@ -185,6 +185,10 @@ func formatObject(depth int, b *bytes.Buffer, dec *json.Decoder) error {
 // while preserving the order in which the keys appear
 func EncodePreserveOrder(b []byte) ([]byte, error) {
 	dec := json.NewDecoder(bytes.NewReader(b))
+	// re float encoding: https://spec.scuttlebutt.nz/datamodel.html#signing-encoding-floats
+	// not particular excited to implement all of the above
+	// this keeps the original value as a string
+	dec.UseNumber()
 	var buf bytes.Buffer
 	t, err := dec.Token()
 	if err != nil {

--- a/message/replace.go
+++ b/message/replace.go
@@ -19,7 +19,11 @@ func unicodeEscapeSome(s string) string {
 	for i, r := range s {
 		// https://spec.scuttlebutt.nz/datamodel.html#signing-encoding-strings
 		// the rest is already handled by %q in encode.go
-		if r == 0x00000C { // (form feed),  \f
+		if r == 0x000008 {
+			// (backspace) \b
+			b.Write([]byte{0x5C, 0x62})
+		} else if r == 0x00000C {
+			// (form feed) \f
 			b.Write([]byte{0x5C, 0x66})
 		} else if r < 0x20 {
 			// TODO: width for multibyte chars


### PR DESCRIPTION
This fixes two identified cases. There might be more.

1) fix \f encoding

Somehow this one wasn't captured by %q in encode.go
There might be a better place for unicodeEscapeSome()

2) keep original string of floats

Reproducing the exact behavior of v8' JSONification of floats is still
troubling.