### PR TITLE
Fix graph build

### DIFF
--- a/graph/builder.go
+++ b/graph/builder.go
@@ -144,7 +144,7 @@ func (b *builder) Build() (*Graph, error) {
 
 			if bytes.Equal(from.ID, to.ID) {
 				// contact self?!
-				return nil
+				continue
 			}
 
 			v, err := it.Value()

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -170,7 +170,7 @@ func (b *builder) Build() (*Graph, error) {
 				known[bto] = nTo
 			}
 
-			w := math.Inf(-1)
+			w := math.Inf(-1) // undefined - will result in a panic when trying to construct dijkstra
 			if len(v) != 1 {
 				return errors.Errorf("badgerGraph: invalid state val(%v) for %s:%s", v, from.Ref(), to.Ref())
 			}
@@ -180,7 +180,7 @@ func (b *builder) Build() (*Graph, error) {
 				if dg.HasEdgeFromTo(nFrom.ID(), nTo.ID()) {
 					dg.RemoveEdge(nFrom.ID(), nTo.ID())
 				}
-				return nil
+				continue // don't add an edge, go to next entry
 			case '1':
 				w = 1
 			case '2': // blocking

--- a/graph/people_test.go
+++ b/graph/people_test.go
@@ -274,6 +274,22 @@ func TestPeople(t *testing.T) {
 				PeopleAssertFollows("bob", "alice", false),
 
 				PeopleAssertAuthorize("alice", "bob", 0, false),
+		},
+
+		{
+			name: "same",
+			ops: []PeopleOp{
+				PeopleOpNewPeer{"alice"},
+				PeopleOpNewPeer{"bob"},
+
+				PeopleOpFollow{"alice", "alice"}, // might happen but shouldn't be a problem
+				PeopleOpFollow{"alice", "bob"},
+			},
+			asserts: []PeopleAssertMaker{
+				PeopleAssertFollows("alice", "bob", true),
+				PeopleAssertFollows("bob", "alice", false),
+
+				PeopleAssertAuthorize("alice", "bob", 0, true),
 			},
 		},
 

--- a/graph/people_test.go
+++ b/graph/people_test.go
@@ -268,12 +268,21 @@ func TestPeople(t *testing.T) {
 				PeopleOpNewPeer{"bob"},
 				PeopleOpFollow{"alice", "bob"},
 				PeopleOpUnfollow{"alice", "bob"},
+
+				// make sure other connections still work
+				PeopleOpNewPeer{"claire"},
+				PeopleOpFollow{"alice", "claire"},
+				PeopleOpFollow{"claire", "bob"},
 			},
 			asserts: []PeopleAssertMaker{
 				PeopleAssertFollows("alice", "bob", false),
 				PeopleAssertFollows("bob", "alice", false),
 
 				PeopleAssertAuthorize("alice", "bob", 0, false),
+
+				PeopleAssertAuthorize("alice", "claire", 0, true),
+				PeopleAssertFollows("claire", "bob", true),
+			},
 		},
 
 		{


### PR DESCRIPTION
 There were two `return`s in the follow-graph builder that aborted the generation of the graph prematurely. This adds tests for those cases and fixes the code by `continue`ing as it was intended in the first place... :see_no_evil: 