### PR TITLE
Secret key file permissions

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -5,6 +5,7 @@ package ssb
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -84,6 +85,14 @@ func LoadKeyPair(fname string) (*KeyPair, error) {
 		return nil, errors.Wrapf(err, "ssb.LoadKeyPair: could not open key file %s", fname)
 	}
 	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrapf(err, "ssb.LoadKeyPair: could not stat key file %s", fname)
+	}
+	if perms := info.Mode().Perm(); perms != SecretPerms {
+		return nil, fmt.Errorf("ssb.LoadKeyPair: expected key file permissions %s, but got %s", SecretPerms, perms)
+	}
 
 	return ParseKeyPair(nocomment.NewReader(f))
 }

--- a/keys.go
+++ b/keys.go
@@ -15,6 +15,9 @@ import (
 	"go.cryptoscope.co/secretstream/secrethandshake"
 )
 
+// SecretPerms are the file permissions for holding SSB secrets.
+const SecretPerms os.FileMode = 0600
+
 type KeyPair struct {
 	Id   *FeedRef
 	Pair secrethandshake.EdKeyPair
@@ -58,7 +61,7 @@ func SaveKeyPair(kp *KeyPair, path string) error {
 		return errors.Errorf("ssb.SaveKeyPair: key already exists:%q", path)
 	}
 	os.MkdirAll(filepath.Dir(path), 0700)
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, SecretPerms)
 	if err != nil {
 		return errors.Wrap(err, "ssb.SaveKeyPair: failed to create file")
 	}

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,0 +1,64 @@
+package ssb
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveKeyPair(t *testing.T) {
+	fname := path.Join(os.TempDir(), "secret")
+
+	keys, err := NewKeyPair(nil)
+	require.NoError(t, err)
+	err = SaveKeyPair(keys, fname)
+	require.NoError(t, err)
+	defer os.Remove(fname)
+
+	stat, err := os.Stat(fname)
+	require.NoError(t, err)
+	assert.Equal(t, SecretPerms, stat.Mode(), "file permissions")
+}
+
+func TestLoadKeyPair(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Perms  os.FileMode
+		HasErr bool
+	}{
+		{
+			"Success",
+			SecretPerms,
+			false,
+		},
+		{
+			"Bad file permissions",
+			0777,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			fname := path.Join(os.TempDir(), "secret")
+
+			keys, err := NewKeyPair(nil)
+			require.NoError(t, err)
+			err = SaveKeyPair(keys, fname)
+			require.NoError(t, err)
+			defer os.Remove(fname)
+
+			err = os.Chmod(fname, test.Perms)
+			require.NoError(t, err)
+
+			_, err = LoadKeyPair(fname)
+			if test.HasErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Save key file with secret key permissions like in ssh, and require secret key permissions like in ssh.