### PR TITLE
Add blobstore option to sbot

### DIFF
--- a/blobstore.go
+++ b/blobstore.go
@@ -28,6 +28,10 @@ type BlobStore interface {
 	// Put stores the data in the reader in the blob store and returns the address.
 	Put(blob io.Reader) (*BlobRef, error)
 
+	// PutExpected makes sure the added blob really is the passedBlobref
+	// helpful for want/get operations which don't want to wast resources
+	// PutExpected(io.Reader, *BlobRef) error
+
 	// Delete deletes a blob from the blob store.
 	Delete(ref *BlobRef) error
 
@@ -70,6 +74,10 @@ func (w BlobWant) String() string {
 type BlobStoreNotification struct {
 	Op  BlobStoreOp
 	Ref *BlobRef
+}
+
+func (bn BlobStoreNotification) String() string {
+	return bn.Op.String() + ": " + bn.Ref.Ref()
 }
 
 // BlobStoreOp specifies the operation in a blob store notification.

--- a/blobstore/store.go
+++ b/blobstore/store.go
@@ -67,11 +67,8 @@ type blobStore struct {
 }
 
 func (store *blobStore) getPath(ref *ssb.BlobRef) (string, error) {
-	if ref.Algo != "sha256" {
-		return "", errors.Errorf("unknown hash algorithm %q", ref.Algo)
-	}
-	if len(ref.Hash) != 32 {
-		return "", errors.Errorf("expected hash length 32, got %v", len(ref.Hash))
+	if err := ref.IsValid(); err != nil {
+		return "", errors.Wrap(err, "blobs: invalid reference")
 	}
 
 	hexHash := hex.EncodeToString(ref.Hash)
@@ -81,11 +78,8 @@ func (store *blobStore) getPath(ref *ssb.BlobRef) (string, error) {
 }
 
 func (store *blobStore) getHexDirPath(ref *ssb.BlobRef) (string, error) {
-	if ref.Algo != "sha256" {
-		return "", errors.Errorf("unknown hash algorithm %q", ref.Algo)
-	}
-	if len(ref.Hash) != 32 {
-		return "", errors.Errorf("expected hash length 32, got %v", len(ref.Hash))
+	if err := ref.IsValid(); err != nil {
+		return "", errors.Wrap(err, "blobs: invalid reference")
 	}
 
 	hexHash := hex.EncodeToString(ref.Hash)

--- a/refs.go
+++ b/refs.go
@@ -282,6 +282,9 @@ func (ref FeedRef) Ref() string {
 }
 
 func (ref FeedRef) Equal(b *FeedRef) bool {
+	if ref.Algo != b.Algo {
+		return false
+	}
 	return bytes.Equal(ref.ID, b.ID)
 }
 
@@ -375,6 +378,23 @@ func ParseBlobRef(s string) (*BlobRef, error) {
 		return nil, errors.Errorf("blobRef: not a blob! %T", ref)
 	}
 	return newRef, nil
+}
+
+func (ref BlobRef) Equal(b *BlobRef) bool {
+	if ref.Algo != b.Algo {
+		return false
+	}
+	return bytes.Equal(ref.Hash, b.Hash)
+}
+
+func (br BlobRef) IsValid() error {
+	if br.Algo != "sha256" {
+		return errors.Errorf("unknown hash algorithm %q", br.Algo)
+	}
+	if len(br.Hash) != 32 {
+		return errors.Errorf("expected hash length 32, got %v", len(br.Hash))
+	}
+	return nil
 }
 
 // MarshalText encodes the BlobRef using Ref()

--- a/sbot/options.go
+++ b/sbot/options.go
@@ -88,6 +88,13 @@ type Sbot struct {
 
 type Option func(*Sbot) error
 
+func WithBlobStore(bs ssb.BlobStore) Option {
+	return func(s *Sbot) error {
+		s.BlobStore = bs
+		return nil
+	}
+}
+
 // DisableLiveIndexMode makes the update processing halt once it reaches the end of the rootLog
 // makes it easier to rebuild indicies.
 func DisableLiveIndexMode() Option {


### PR DESCRIPTION
This extracts `BlobRef.IsValid()` from the fs-based store and also adds an option to sbot (`WithBlobStore`) so that implementations can be switched out.