### PR TITLE
various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,16 @@ go-sbot &
 sbotcli connect "net:some.ho.st:8008~shs:SomeActuallyValidPubKey="
 ```
 
+### Startup error / no mmio
+
+The badger key-value database defaults to loading some of it's files using [memory-mapped i/o](https://en.wikipedia.org/wiki/Memory-mapped_I/O). If this turns out to be a problem on your target platform, you can use `go build -tags nommio` when building to fall back to standard files, which can be a bit slower but should still be fully functional.
+
+The error can look like this:
+
+```
+badger failed to open: Mmap value log file. Path=C:\\some\\where\\.ssb-go\\indexes\\contacts\\db\\000000.vlog. Error=MapViewOfFile: Not enough memory resources are available to process this command.
+```
+
 ## Stack links
 
 * [secret-handshake](https://secret-handshake.club) key exchange using [secretstream](https://godoc.org/go.cryptoscope.co/secretstream)

--- a/keys.go
+++ b/keys.go
@@ -16,9 +16,6 @@ import (
 	"go.cryptoscope.co/secretstream/secrethandshake"
 )
 
-// SecretPerms are the file permissions for holding SSB secrets.
-const SecretPerms os.FileMode = 0600
-
 type KeyPair struct {
 	Id   *FeedRef
 	Pair secrethandshake.EdKeyPair

--- a/keys_default.go
+++ b/keys_default.go
@@ -1,0 +1,9 @@
+// +build linux freebsd darwin
+
+package ssb
+
+import "os"
+
+// SecretPerms are the file permissions for holding SSB secrets.
+// We expect the file to only be accessable by the owner.
+var SecretPerms = os.FileMode(0600)

--- a/keys_windows.go
+++ b/keys_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package ssb
+
+import (
+	"os"
+)
+
+// SecretPerms are the file permissions for holding SSB secrets.
+// Windows has it's own permission system apart from UNIX (owner, group, others)
+var SecretPerms = os.FileMode(0666)

--- a/repo/badger_default.go
+++ b/repo/badger_default.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// +build freebsd linux windows darwin,amd64 darwin,386
+// +build !nommio
 
 package repo
 

--- a/repo/badger_ios.go
+++ b/repo/badger_ios.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// +build darwin
-// +build arm arm64
+// +build nommio
 
 package repo
 


### PR DESCRIPTION
###  b9735bc: add `nommio` build tag

use `go build -tags nommio` to fix #51 

cc @freight-stack i think you needed this for your Pi

cc @pietgeursen i guess the gobot for sunrise-social could use this update, too.



### 96d5071:  re-do #54 but without using the `runtime` package
this uses the '// +build ...'  quasi-macro at compile-time
to decide which perms to check the secret file for.

closes #54
updates #52

cc @soapdog could you try this?