### PR TITLE
Fix expected permissions of the secret file on OSX

### DIFF
--- a/keys_darwin.go
+++ b/keys_darwin.go
@@ -1,0 +1,9 @@
+// +build darwin
+
+package ssb
+
+import "os"
+
+// SecretPerms are the file permissions for holding SSB secrets.
+// OSX installation expects the file to be read only by the owner.
+var SecretPerms = os.FileMode(0400)

--- a/keys_default.go
+++ b/keys_default.go
@@ -1,4 +1,4 @@
-// +build linux freebsd darwin
+// +build linux freebsd
 
 package ssb
 


### PR DESCRIPTION
Bootstrapping from secret generated by the latest version of Patchwork causes an error:

- https://github.com/cryptoscope/ssb/issues/52#issuecomment-644621296

Having OSX-specific `keys.SecretPerms` fixes the problem.