### PR TITLE
private groups reindex

### DIFF
--- a/multilogs/combined.go
+++ b/multilogs/combined.go
@@ -234,6 +234,10 @@ func (slog *CombinedIndex) update(seq int64, msg refs.Message) error {
 		return fmt.Errorf("ssb: untyped message")
 	}
 
+	if typeStr == "group/add-member" {
+		fmt.Printf("\n=======>\n%s %d\n\t=======>\nadd member message from %s:%d\n", slog.self.Ref(), seq, author.Ref(), msg.Seq())
+	}
+
 	typedLog, err := slog.byType.Get(librarian.Addr("string:" + typeStr))
 	if err != nil {
 		return errors.Wrap(err, "error opening sublog")

--- a/multilogs/membership_index.go
+++ b/multilogs/membership_index.go
@@ -1,0 +1,170 @@
+package multilogs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.cryptoscope.co/librarian"
+	libmkv "go.cryptoscope.co/librarian/mkv"
+	"go.cryptoscope.co/margaret"
+	"go.cryptoscope.co/ssb/private"
+	"go.cryptoscope.co/ssb/repo"
+	refs "go.mindeco.de/ssb-refs"
+)
+
+type Members map[string]bool
+
+type MembershipStore struct {
+	idx librarian.SeqSetterIndex
+
+	self *refs.FeedRef
+
+	unboxer *private.Manager
+
+	combinedidx *CombinedIndex
+}
+
+var _ io.Closer = (*MembershipStore)(nil)
+
+func NewMembershipIndex(r repo.Interface, self *refs.FeedRef, unboxer *private.Manager, comb *CombinedIndex) (*MembershipStore, librarian.SinkIndex, error) {
+
+	pth := r.GetPath(repo.PrefixIndex, "groups", "members", "mkv")
+	err := os.MkdirAll(pth, 0700)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "openIndex: error making index directory")
+	}
+
+	db, err := repo.OpenMKV(pth)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "openIndex: failed to open MKV database")
+	}
+	var store = MembershipStore{
+		idx: libmkv.NewIndex(db, Members{}),
+
+		self: self,
+
+		unboxer: unboxer,
+
+		combinedidx: comb,
+	}
+
+	snk := librarian.NewSinkIndex(store.updateFn, store.idx)
+	return &store, snk, nil
+}
+
+func (mc MembershipStore) Close() error {
+	return mc.idx.Close()
+}
+
+func (mc MembershipStore) updateFn(ctx context.Context, seq margaret.Seq, val interface{}, idx librarian.SetterIndex) error {
+	msg, ok := val.(refs.Message)
+	if !ok {
+		return fmt.Errorf("not a message: %T", val)
+	}
+
+	if msg.Author().Equal(mc.self) {
+		// our own message - all is done already
+		fmt.Println("skipping invite from self")
+		return nil
+	}
+
+	cleartext, err := mc.unboxer.DecryptMessage(msg)
+	if err != nil {
+		return nil // invalid message
+	}
+
+	fmt.Println("new add member message:", msg.Key().Ref())
+	fmt.Println(string(cleartext))
+
+	var addMemberMsg private.GroupAddMember
+	err = json.Unmarshal(cleartext, &addMemberMsg)
+	if err != nil {
+		return nil // invalid message
+	}
+
+	var groupID *refs.MessageRef
+	var newMembers []*refs.FeedRef
+	for _, r := range addMemberMsg.Recps {
+		rcp, err := refs.ParseMessageRef(r)
+		if err == nil && rcp.Algo == refs.RefAlgoCloakedGroup {
+			groupID = rcp
+			continue
+		}
+
+		m, err := refs.ParseFeedRef(r)
+		if err != nil {
+			return nil // invalid message
+		}
+		newMembers = append(newMembers, m)
+	}
+
+	if groupID == nil {
+		return nil // invalid message
+	}
+
+	// TODO: are we addded? call Join() to save the key
+
+	/* TODO? not really required but would fit into the existing scheme
+	   then again, we would need to allocate a value in tfk for this...
+
+		groupAsTFK, err := tfk.Encode(groupID)
+		if err != nil {
+			return err
+		}
+	*/
+
+	idxAddr := librarian.Addr(groupID.Hash)
+	state, err := mc.idx.Get(ctx, idxAddr)
+	if err != nil {
+		return err
+	}
+
+	statev, err := state.Value()
+	if err != nil {
+		return err
+	}
+
+	var currentMembers Members
+	switch tv := statev.(type) {
+	case Members:
+		currentMembers = tv
+	case librarian.UnsetValue:
+		currentMembers = make(Members, 0)
+	default:
+		return fmt.Errorf("not a Member: %T", statev)
+	}
+
+	for _, nm := range newMembers {
+		_, indexed := currentMembers[nm.Ref()]
+		if !indexed {
+			whoToIndex := nm
+			if nm.Equal(mc.self) {
+				// if we are invited, we need to index the sending author
+				whoToIndex = msg.Author()
+			}
+
+			go func(f *refs.FeedRef) {
+				time.Sleep(7 * time.Second)
+				err = mc.combinedidx.Box2Reindex(f)
+				if err != nil {
+					panic(err)
+				}
+			}(whoToIndex)
+
+			// mark as indexed
+			currentMembers[nm.Ref()] = true
+		}
+	}
+
+	err = mc.idx.Set(ctx, idxAddr, currentMembers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/multilogs/membership_index.go
+++ b/multilogs/membership_index.go
@@ -73,7 +73,7 @@ func (mc MembershipStore) updateFn(ctx context.Context, seq margaret.Seq, val in
 		return nil // invalid message
 	}
 
-	fmt.Println("new add member message:", msg.Key().Ref())
+	fmt.Printf("\n######## %s\nnew add member message: %s\n", mc.self.Ref(), msg.Key().Ref())
 	fmt.Println(string(cleartext))
 
 	var addMemberMsg private.GroupAddMember
@@ -154,7 +154,7 @@ func (mc MembershipStore) updateFn(ctx context.Context, seq margaret.Seq, val in
 			}
 
 			// mark as indexed
-			currentMembers[nm.Ref()] = true
+			currentMembers[whoToIndex.Ref()] = true
 		}
 	}
 

--- a/network/new.go
+++ b/network/new.go
@@ -100,7 +100,7 @@ func New(opts Options) (ssb.Network, error) {
 	}
 
 	if opts.ConnTracker == nil {
-		opts.ConnTracker = NewAcceptAllTracker()
+		opts.ConnTracker = NewLastWinsTracker()
 	}
 	n.connTracker = opts.ConnTracker
 

--- a/plugins/groups/handler.go
+++ b/plugins/groups/handler.go
@@ -44,31 +44,10 @@ func New(log logging.Interface, groups *private.Manager) ssb.Plugin {
 		groups: groups,
 	})
 
-	/*
-		rootHdlr.RegisterAsync(muxrpc.Method{"friends", "isBlocking"}, isBlockingH{
-			log:     log,
-			builder: b,
-			self:    self,
-		})
-
-		rootHdlr.RegisterSource(muxrpc.Method{"friends", "blocks"}, blocksSrc{
-			log:     log,
-			builder: b,
-			self:    self,
-		})
-
-		rootHdlr.RegisterSource(muxrpc.Method{"friends", "hops"}, hopsSrc{
-			log:     log,
-			builder: b,
-			self:    self,
-		})
-
-		rootHdlr.RegisterAsync(muxrpc.Method{"friends", "plotsvg"}, plotSVGHandler{
-			log:     log,
-			builder: b,
-			self:    self,
-		})
-	*/
+	rootHdlr.RegisterAsync(append(method, "invite"), invite{
+		log:    log,
+		groups: groups,
+	})
 
 	return plugin{
 		h:   &rootHdlr,

--- a/plugins/groups/is.go
+++ b/plugins/groups/is.go
@@ -77,59 +77,41 @@ func (h publishTo) HandleAsync(ctx context.Context, req *muxrpc.Request) (interf
 	return newMsg.Ref(), nil
 }
 
-/*
-type isBlockingH struct {
-	self refs.FeedRef
-
+type invite struct {
 	log log.Logger
 
-	builder graph.Builder
+	groups *private.Manager
 }
 
-func (h isBlockingH) HandleAsync(ctx context.Context, req *muxrpc.Request) (interface{}, error) {
-	var args []sourceDestArg
+func (h invite) HandleAsync(ctx context.Context, req *muxrpc.Request) (interface{}, error) {
+	var args []json.RawMessage
 	if err := json.Unmarshal(req.RawArgs, &args); err != nil {
-		return nil, fmt.Errorf("invalid argument on isBlocking call: %w", err)
+		return nil, fmt.Errorf("invalid argument on publishTo call: %w", err)
 	}
-	if len(args) != 1 {
-		return nil, fmt.Errorf("expected one arg {source, dest}")
+	if len(args) != 2 {
+		return nil, fmt.Errorf("expected two args [groupID, content]")
 	}
-	a := args[0]
 
-	g, err := h.builder.Build()
+	var groupID refs.MessageRef
+	err := json.Unmarshal(args[0], &groupID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("groupID needs to be a valid message ref: %w", err)
 	}
 
-	return g.Blocks(&a.Source, &a.Dest), nil
+	if groupID.Algo != refs.RefAlgoCloakedGroup {
+		return nil, fmt.Errorf("groupID needs to be a cloaked message ref, not %s", groupID.Algo)
+	}
+
+	var newMember refs.FeedRef
+	err = json.Unmarshal(args[1], &newMember)
+	if err != nil {
+		return nil, fmt.Errorf("member needs to be a valid feed ID: %w", err)
+	}
+
+	newMsg, err := h.groups.AddMember(&groupID, &newMember, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to publish invite to group")
+	}
+
+	return newMsg.Ref(), nil
 }
-
-type plotSVGHandler struct {
-	self refs.FeedRef
-
-	log log.Logger
-
-	builder graph.Builder
-}
-
-func (h plotSVGHandler) HandleAsync(ctx context.Context, req *muxrpc.Request) (interface{}, error) {
-	g, err := h.builder.Build()
-	if err != nil {
-		return nil, err
-	}
-
-	fname, err := ioutil.TempFile("", "graph-*.svg")
-	if err != nil {
-		return nil, err
-	}
-
-	err = g.RenderSVG(fname)
-	if err != nil {
-		fname.Close()
-		os.Remove(fname.Name())
-		return nil, err
-	}
-
-	return fname.Name(), fname.Close()
-}
-*/

--- a/plugins/rawread/logt.go
+++ b/plugins/rawread/logt.go
@@ -158,7 +158,8 @@ func (g Plugin) HandleSource(ctx context.Context, req *muxrpc.Request, snk luigi
 	// not live
 	typed, err := g.types.LoadInternalBitmap(idxAddr)
 	if err != nil {
-		return errors.Wrap(err, "failed to load typed log")
+		return snk.Close()
+		//		return errors.Wrap(err, "failed to load typed log")
 	}
 
 	if qry.Private {
@@ -234,7 +235,6 @@ func (g Plugin) HandleSource(ctx context.Context, req *muxrpc.Request, snk luigi
 func newSinkCounter(counter *int, sink luigi.Sink) luigi.FuncSink {
 	return func(ctx context.Context, v interface{}, err error) error {
 		if err != nil {
-			fmt.Println("weird", err)
 			return err
 		}
 

--- a/private/groups_test.go
+++ b/private/groups_test.go
@@ -363,7 +363,7 @@ func TestGroupsReindex(t *testing.T) {
 	err = srh.Network.Connect(ctx, tal.Network.GetListenAddr())
 	r.NoError(err)
 
-	time.Sleep(20 * time.Second) // TODO: preferably remove me
+	time.Sleep(2 * time.Second) // let them sync
 
 	// indexed?
 	chkCount := func(ml *roaring.MultiLog) func(tipe librarian.Addr, cnt int) {

--- a/repo/timestamp_sorter.go
+++ b/repo/timestamp_sorter.go
@@ -301,6 +301,13 @@ func (sr *SequenceResolver) Append(seq int64, feed int64, claimed, received time
 	}
 
 	if has := int64(len(sr.seq2claimed)); has != seq {
+		if seq < has {
+			// assuming reindex - value wouldnt change
+			// TODO: maybe received? but not really...
+			// could be  a side-channel for _new messages_
+			// but it's a dirty hack - rather use _readable index_ message count
+			return nil
+		}
 		return fmt.Errorf("seq resolver: would break const (has:%d, will: %d)", has, seq)
 	}
 

--- a/repo/timestamp_sorter.go
+++ b/repo/timestamp_sorter.go
@@ -90,11 +90,10 @@ func NewSequenceResolver(r Interface) (*SequenceResolver, error) {
 	var sr SequenceResolver
 	sr.repo = r
 
-	n, err := sr.Load()
+	_, err := sr.Load()
 	if err != nil {
 		return nil, fmt.Errorf("seq resolver: failed to load: %w", err)
 	}
-	fmt.Printf("sr: has %d entries\n", n)
 
 	return &sr, nil
 }

--- a/sbot/new.go
+++ b/sbot/new.go
@@ -391,7 +391,7 @@ func initSbot(s *Sbot) (*Sbot, error) {
 	}
 
 	// publish
-	s.master.Register(publish.NewPlug(kitlog.With(log, "plugin", "publish"), s.PublishLog, s.ReceiveLog))
+	s.master.Register(publish.NewPlug(kitlog.With(log, "unit", "publish"), s.PublishLog, s.ReceiveLog))
 
 	// private
 	// TODO: box2
@@ -400,19 +400,19 @@ func initSbot(s *Sbot) (*Sbot, error) {
 		return nil, errors.Wrap(err, "failed to open user private index")
 	}
 	s.master.Register(privplug.NewPlug(
-		kitlog.With(log, "plugin", "private"),
+		kitlog.With(log, "unit", "private"),
 		s.KeyPair.Id,
 		s.Groups,
 		s.PublishLog,
 		private.NewUnboxerLog(s.ReceiveLog, userPrivs, s.KeyPair)))
 
 	// whoami
-	whoami := whoami.New(kitlog.With(log, "plugin", "whoami"), s.KeyPair.Id)
+	whoami := whoami.New(kitlog.With(log, "unit", "whoami"), s.KeyPair.Id)
 	s.public.Register(whoami)
 	s.master.Register(whoami)
 
 	// blobs
-	blobs := blobs.New(kitlog.With(log, "plugin", "blobs"), *s.KeyPair.Id, s.BlobStore, wm)
+	blobs := blobs.New(kitlog.With(log, "unit", "blobs"), *s.KeyPair.Id, s.BlobStore, wm)
 	s.public.Register(blobs)
 	s.master.Register(blobs) // TODO: does not need to open a createWants on this one?!
 
@@ -440,18 +440,18 @@ func initSbot(s *Sbot) (*Sbot, error) {
 		ctx,
 		s.ReceiveLog,
 		s.Users,
-		kitlog.With(log, "feedmanager"),
+		kitlog.With(log, "unit", "gossip"),
 		s.systemGauge,
 		s.eventCounter,
 	)
 	s.public.Register(gossip.New(ctx,
-		kitlog.With(log, "plugin", "gossip"),
+		kitlog.With(log, "unit", "gossip"),
 		s.KeyPair.Id, s.ReceiveLog, s.Users, fm, s.Replicator.Lister(),
 		histOpts...))
 
 	// incoming createHistoryStream handler
 	hist := gossip.NewHist(ctx,
-		kitlog.With(log, "plugin", "gossip/hist"),
+		kitlog.With(log, "unit", "gossip/hist"),
 		s.KeyPair.Id,
 		s.ReceiveLog, s.Users,
 		s.Replicator.Lister(),
@@ -566,7 +566,7 @@ func initSbot(s *Sbot) (*Sbot, error) {
 	s.Network.HandleHTTP(h)
 
 	inviteService, err = legacyinvites.New(
-		kitlog.With(log, "plugin", "legacyInvites"),
+		kitlog.With(log, "unit", "legacyInvites"),
 		r,
 		s.KeyPair.Id,
 		s.Network,
@@ -579,7 +579,7 @@ func initSbot(s *Sbot) (*Sbot, error) {
 	s.master.Register(inviteService.MasterPlugin())
 
 	// TODO: should be gossip.connect but conflicts with our namespace assumption
-	s.master.Register(control.NewPlug(kitlog.With(log, "plugin", "ctrl"), s.Network, s))
+	s.master.Register(control.NewPlug(kitlog.With(log, "unit", "ctrl"), s.Network, s))
 	s.master.Register(status.New(s))
 
 	return s, nil

--- a/sbot/new.go
+++ b/sbot/new.go
@@ -202,6 +202,7 @@ func initSbot(s *Sbot) (*Sbot, error) {
 		s.repoPath,
 		s.Groups,
 		s.KeyPair.Id,
+		s.ReceiveLog,
 		s.SeqResolver,
 		s.Users,
 		s.Private,
@@ -214,7 +215,6 @@ func initSbot(s *Sbot) (*Sbot, error) {
 	s.closers.addCloser(combIdx)
 
 	// groups re-indexing
-
 	members, membersSnk, err := multilogs.NewMembershipIndex(r, s.KeyPair.Id, s.Groups, combIdx)
 	if err != nil {
 		return nil, errors.Wrap(err, "sbot: failed to open group membership index")


### PR DESCRIPTION
This takes advantage of set operation on roaring bitmaps that we keep per author, per message type and per _decryptable by us_. This way we can construct the set of _whose messages of this author are box2 but not yet readable_ and just reindex those.

The first attempt showed a problem with the bitmap indexes where the order is not kept as (previous) messages are added. ie first message is A and the set is [A]. As a message B which is before A is discovered (decrypted) it get's added to the same set but since its receive sequence is smaller then A the set looks like [B, A] and reading the 2nd message from that set will result in processing A twice.

As a workaround I'm loading an older _badger multilog_ index which keeps the order (the set is [A,B]). A better approach would be to use the serialized array functionality which we use for the timestamp sorting.