### PR TITLE
Add dev docs (treasure map link) section to  readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ WARNING: Project is still in alpha, backwards incompatible changes will be made.
 
 If you encounter a bug, please refer to our [public issue tracker](https://github.com/cryptoscope/ssb/issues).
 
+### Developing
+Want to contribute patches to go-ssb? Read the [developer documentation](https://dev.scuttlebutt.nz/#/golang/) hosted at [dev.scuttlebutt.nz](https://dev.scuttlebutt.nz/#/golang/). If you have a large change you want to make, reach out to [@cryptix](https://github.com/cryptix) first and we'll together make sure that the resulting PR will be accepted :black_heart:
+
 ## Server Features
 
 * [x] Follow-graph implementation (based on [gonum](https://www.gonum.org)) to authorize incoming connections


### PR DESCRIPTION
Added a subsection to the first section of the readme with a link to the dev docs at https://dev.scuttlebutt.nz/#/golang/