### PR TITLE
Set stricter permissions as default, try to chmod incorrect permissions automatically

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -184,8 +184,13 @@ func LoadKeyPair(fname string) (KeyPair, error) {
 		return nil, fmt.Errorf("ssb.LoadKeyPair: could not stat key file %s: %w", fname, err)
 	}
 
+	// secret key permissions are not what they should be
 	if perms := info.Mode().Perm(); perms != SecretPerms {
-		return nil, fmt.Errorf("ssb.LoadKeyPair: expected key file permissions %s, but got %s", SecretPerms, perms)
+		// try to correct permissions on secret
+		err = os.Chmod(fname, SecretPerms)
+		if err != nil {
+			return nil, fmt.Errorf("ssb.LoadKeyPair: failed to correct permissions from %s to %s (%w)", perms, SecretPerms, err)
+		}
 	}
 
 	kp, err := ParseKeyPair(nocomment.NewReader(f))

--- a/keys_default.go
+++ b/keys_default.go
@@ -11,4 +11,4 @@ import "os"
 
 // SecretPerms are the file permissions for holding SSB secrets.
 // We expect the file to only be accessable by the owner.
-var SecretPerms = os.FileMode(0600)
+var SecretPerms = os.FileMode(0400)

--- a/keys_test.go
+++ b/keys_test.go
@@ -32,7 +32,7 @@ func TestLoadKeyPair(t *testing.T) {
 	tests := []struct {
 		Name   string
 		Perms  os.FileMode
-		HasErr bool
+		HasIncorrectPermissions bool
 	}{
 		{
 			"Success",
@@ -40,7 +40,7 @@ func TestLoadKeyPair(t *testing.T) {
 			false,
 		},
 		{
-			"Bad file permissions",
+			"Bad file permissions, should be corrected",
 			0777,
 			true,
 		},
@@ -59,8 +59,10 @@ func TestLoadKeyPair(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = LoadKeyPair(fname)
-			if test.HasErr {
-				assert.Error(t, err)
+			if test.HasIncorrectPermissions {
+				info, err := os.Stat(fname)
+				assert.NoError(t, err)
+				assert.EqualValues(t, info.Mode().Perm(), SecretPerms, "incorrect permissions have not been corrected automatically")
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
This PR comes in two:
1. A fix for the default permissions, making them stricter 
2. An experimental tweak to the permissions behaviour, where go-sbot tries to set any incorrect permissions to what it expects (rather than error out and force users to deal with it)

@cryptix I'm okay with if you wanna throw out part 2, but I wanted to have a try at it since I think it's a bit nicer for users :)

Related to and fixes #131