### PR TITLE
OS/ISA matrix for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ PKGS := $(shell go list ./... | grep -v node_modules )
 
 TESTFLAGS = -failfast -timeout 5m
 
+
+ZIPPER := zstd -9
+ifeq (, $(shell which zstd))
+ZIPPER := gzip
+endif
+
 # echo -en "\n        $(pkg)\r";
 # this echo is just a trick to print the packge that is tested 
 # and then returning the carriage to let the go test invocation print the result over the line
@@ -27,21 +33,23 @@ BUILD=$(shell date +%FT%T%z)
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.Build=${BUILD}"
 
-PLATFORMS := windows linux darwin freebsd
-os = $(word 1, $@)
+PLATFORMS := windows-amd64 windows-arm64 linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 freebsd-amd64
+os = $(word 1,$(subst -, ,$@))
+arch = $(word 2,$(subst -, ,$@))
 
-ARCHIVENAME=release/$(os)-$(VERSION).tar
+ARCHIVENAME=release/$(os)-$(arch)-$(VERSION).tar
 
 .PHONY: $(PLATFORMS)
+
 $(PLATFORMS):
-	GOOS=$(os) GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o go-sbot ./cmd/go-sbot
-	GOOS=$(os) GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o sbotcli ./cmd/sbotcli
-	GOOS=$(os) GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o gossb-truncate-log ./cmd/ssb-truncate-log
-	GOOS=$(os) GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o ssb-offset-converter ./cmd/ssb-offset-converter
+	GOOS=$(os) GOARCH=$(arch) go build -v -i -trimpath $(LDFLAGS) -o go-sbot ./cmd/go-sbot
+	GOOS=$(os) GOARCH=$(arch) go build -v -i -trimpath $(LDFLAGS) -o sbotcli ./cmd/sbotcli
+	GOOS=$(os) GOARCH=$(arch) go build -v -i -trimpath $(LDFLAGS) -o gossb-truncate-log ./cmd/ssb-truncate-log
+	GOOS=$(os) GOARCH=$(arch) go build -v -i -trimpath $(LDFLAGS) -o ssb-offset-converter ./cmd/ssb-offset-converter
 	tar cvf $(ARCHIVENAME) go-sbot sbotcli gossb-truncate-log ssb-offset-converter 
 	rm go-sbot sbotcli gossb-truncate-log ssb-offset-converter
-	zstd -9 $(ARCHIVENAME)
-	rm $(ARCHIVENAME)
+	$(ZIPPER) $(ARCHIVENAME)
+	rm $(ARCHIVENAME) || true
 
 .PHONY: release
-release: windows linux darwin freebsd
+release: windows-amd64 windows-arm64 linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 freebsd-amd64

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,32 @@ $(PLATFORMS):
 	$(ZIPPER) $(ARCHIVENAME)
 	rm $(ARCHIVENAME) || true
 
+.PHONY: darwin-universal
+darwin-universal:
+ifeq (, $(shell which lipo))
+	$(info darwin-universal can only be made if lipo binary is available.)
+else
+	GOOS=darwin GOARCH=arm64 go build -v -i -trimpath $(LDFLAGS) -o go-sbot-arm64 ./cmd/go-sbot
+	GOOS=darwin GOARCH=arm64 go build -v -i -trimpath $(LDFLAGS) -o sbotcli-arm64 ./cmd/sbotcli
+	GOOS=darwin GOARCH=arm64 go build -v -i -trimpath $(LDFLAGS) -o gossb-truncate-log-arm64 ./cmd/ssb-truncate-log
+	GOOS=darwin GOARCH=arm64 go build -v -i -trimpath $(LDFLAGS) -o ssb-offset-converter-arm64 ./cmd/ssb-offset-converter
+
+	GOOS=darwin GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o go-sbot-amd64 ./cmd/go-sbot
+	GOOS=darwin GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o sbotcli-amd64 ./cmd/sbotcli
+	GOOS=darwin GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o gossb-truncate-log-amd64 ./cmd/ssb-truncate-log
+	GOOS=darwin GOARCH=amd64 go build -v -i -trimpath $(LDFLAGS) -o ssb-offset-converter-amd64 ./cmd/ssb-offset-converter
+
+	lipo -create go-sbot-arm64 go-sbot-amd64 -o go-sbot
+	lipo -create sbotcli-arm64 sbotcli-amd64 -o sbotcli
+	lipo -create gossb-truncate-log-arm64 gossb-truncate-log-amd64 -o gossb-truncate-log
+	lipo -create ssb-offset-converter-arm64 ssb-offset-converter-amd64 -o ssb-offset-converter 
+
+	tar cvf $(ARCHIVENAME) go-sbot sbotcli gossb-truncate-log ssb-offset-converter 
+	rm go-sbot sbotcli gossb-truncate-log ssb-offset-converter
+	$(ZIPPER) $(ARCHIVENAME)
+	rm $(ARCHIVENAME) || true
+endif
+
+
 .PHONY: release
-release: windows-amd64 windows-arm64 linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 freebsd-amd64
+release: windows-amd64 windows-arm64 linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 darwin-universal freebsd-amd64


### PR DESCRIPTION
This PR is a small QoL addition to making go-ssb releases. It changes the `Makefile` to use an OS/ISA matrix that allows it to build for multiple operating systems and multiple architectures. There is also a special case to build universal binaries for macOS that only works from a mac.