### PR TITLE
Always replicate your own feed

### DIFF
--- a/sbot/new.go
+++ b/sbot/new.go
@@ -605,12 +605,6 @@ func New(fopts ...Option) (*Sbot, error) {
 			return s.public.MakeHandler(conn)
 		}
 
-		// TOFU restore/resync
-		if lst, err := s.Users.List(); err == nil && len(lst) == 0 {
-			level.Warn(s.info).Log("event", "no stored feeds - attempting re-sync with trust-on-first-use")
-			s.Replicate(s.KeyPair.ID())
-			return s.public.MakeHandler(conn)
-		}
 		return nil, err
 	}
 

--- a/sbot/replicate.go
+++ b/sbot/replicate.go
@@ -64,6 +64,7 @@ func (s *Sbot) newGraphReplicator() (*graphReplicator, error) {
 	var r graphReplicator
 	r.bot = s
 	r.current = newLister()
+	r.current.feedWants.AddRef(s.KeyPair.ID())
 
 	replicateEvt := log.With(s.info, "event", "update-replicate")
 	update := r.makeUpdater(replicateEvt, s.KeyPair.ID(), int(s.hopCount))


### PR DESCRIPTION
It appears that go-ssb has a mechanism for replicating your own feed
which is supposed to be triggered if the local database is removed.
Unfortunately the current implementation of this mechanism has two
problems:
- it appears that if the feed wasn't fully replicated then the
  replication will not be resumed unless it manages to fully complete
  during the first attempt
- this mechanism will never be triggered if an authoriser which
  authorises all connections (always returns nil) is set through
  WithPublicAuthorizer

To mitigate this I ensured that the local feed will always be present in
the list of feeds to be replicated.

An additional bug that I discovered appears to prevent the list of
wanted feeds to be updated if the receive log is empty.
This may be a desired behaviour however it prevented me from placing a
line with my fix within the update method of graphReplicator.