### PR TITLE
Fix passing lock by value

### DIFF
--- a/sbot/get.go
+++ b/sbot/get.go
@@ -12,7 +12,7 @@ import (
 	refs "go.mindeco.de/ssb-refs"
 )
 
-func (s Sbot) Get(ref refs.MessageRef) (refs.Message, error) {
+func (s *Sbot) Get(ref refs.MessageRef) (refs.Message, error) {
 	getIdx, ok := s.simpleIndex["get"]
 	if !ok {
 		return nil, fmt.Errorf("sbot: get index disabled")


### PR DESCRIPTION
This was found by running go vet:

	sbot/get.go:15:9: Get passes lock by value: go.cryptoscope.co/ssb/sbot.Sbot contains go.cryptoscope.co/ssb/internal/multicloser.MultiCloser contains sync.Mutex