### PR TITLE
Switch away from FileIO as Badger's value loading mode

### DIFF
--- a/repo/badger_ios.go
+++ b/repo/badger_ios.go
@@ -2,20 +2,17 @@
 //
 // SPDX-License-Identifier: MIT
 
+//go:build nommio
 // +build nommio
 
 package repo
 
 import (
 	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
 )
 
 func badgerOpts(dbPath string) badger.Options {
-	opts := badger.DefaultOptions(dbPath)
-	opts.Logger = nil
-	// runtime throws MMIO can't allocate errors without this
-	// => badger failed to open: Invalid ValueLogLoadingMode, must be FileIO or MemoryMap
-	opts.ValueLogLoadingMode = options.FileIO
-	return opts
+	return badger.DefaultOptions(dbPath).
+		WithValueLogFileSize(1 << 21).
+		WithLogger(nil)
 }


### PR DESCRIPTION
Those options were removed in dgraph-io/badger@e3a0d29. To keep the
memory footprint low on mobile devices ValueLogFileSize was set to 2MB.
Preliminary testing shows that this configuration correctly works on
mobile devices, namely iPhones. This change should then be at least
partially compatibile with the previous settings.